### PR TITLE
feat: render anyOf and nullable unions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@automatons/parser": "^1.0.0",
-    "@automatons/tools": "^2.0.0",
+    "@automatons/parser": "^1.1.0",
+    "@automatons/tools": "^2.1.0",
     "prettier": "^3.8.3",
     "ts-morph": "^28.0.0"
   },

--- a/src/generator/schema.spec.ts
+++ b/src/generator/schema.spec.ts
@@ -31,9 +31,12 @@ describe("schemaToType", () => {
     expect(schemaToType({type: "model", name: "Pet"})).toBe("Pet");
   });
 
-  it("renders allOf and oneOf", () => {
+  it("renders allOf, oneOf and anyOf", () => {
     expect(schemaToType({type: "allOf", schemas: [{type: "model", name: "A"}, {type: "model", name: "B"}]})).toBe("(A & B)");
     expect(schemaToType({type: "oneOf", schemas: [{type: "model", name: "A"}, {type: "model", name: "B"}]})).toBe("(A | B)");
+    expect(schemaToType({type: "anyOf", schemas: [{type: "model", name: "A"}, {type: "model", name: "B"}]})).toBe("(A | B)");
+    expect(schemaToType({type: "oneOf", nullable: true, schemas: [{type: "model", name: "A"}, {type: "model", name: "B"}]})).toBe("(A | B) | null");
+    expect(schemaToType({type: "allOf", nullable: true, schemas: [{type: "model", name: "A"}, {type: "model", name: "B"}]})).toBe("(A & B) | null");
   });
 
   it("renders objects with properties", () => {

--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -27,9 +27,10 @@ export const schemaToType = (schema: Schema): string => {
       return `object${nullable(schema)}`;
     }
     case "allOf":
-      return `(${schema.schemas.map(schemaToType).join(" & ")})`;
+      return `(${schema.schemas.map(schemaToType).join(" & ")})${nullable(schema)}`;
     case "oneOf":
-      return `(${schema.schemas.map(schemaToType).join(" | ")})`;
+    case "anyOf":
+      return `(${schema.schemas.map(schemaToType).join(" | ")})${nullable(schema)}`;
     case "array":
       return `${schema.items ? `Array<${schemaToType(schema.items)}>` : "any[]"}${nullable(schema)}`;
     case "boolean":

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,18 +43,18 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@automatons/parser@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@automatons/parser/-/parser-1.0.0.tgz#9b3cf2d119ec5b8be6d079dd8b812c2cf3bb36ed"
-  integrity sha512-t0hRkE1Kiofno4smRDJ0PsBvCo3Tkp0+J1xe1JlAp5RXM1VzNu3IoSkN7rxO/X4y9SN8/09uUxpGB+DwhTfepg==
+"@automatons/parser@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@automatons/parser/-/parser-1.1.0.tgz#ab7c1dd3014f9d3477ceffe99d2af55104331f00"
+  integrity sha512-8gnA79Ch/TGDaXBO/3ueP+SB42gwlU9kJn34ilR99CubR106j+ZENL7NqTqgMHknH00tBXyK7z+CqJe5WZxXlg==
   dependencies:
-    "@automatons/tools" "^2.0.0"
+    "@automatons/tools" "^2.1.0"
     change-case "^5.4.4"
 
-"@automatons/tools@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.0.1.tgz#1de28b8f3b925319d317515034e0530adba19a35"
-  integrity sha512-l7eUj0OA/p1z7xkpf7kwOGGRQBl2aqVUzXht3C85T1DDYHhXDpUz9v+1w5ckdO37nN4EBIQhAyjpOQ9i30ahzg==
+"@automatons/tools@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.1.0.tgz#b8bb2f4495b011d1aacd4cd094df506cebde6dc1"
+  integrity sha512-l7Vu9qFqz8qG7lyBw8BweEIJtZAnKGHir/Og+2IVKmBoXtu0y36V3UxLGUsBf0pgiin4ymMeoPNksO38cXBVOw==
   dependencies:
     js-yaml "^4.1.0"
 


### PR DESCRIPTION
Renders `anyOf` schemas as TypeScript unions (like `oneOf`) and appends `| null` to allOf/oneOf/anyOf unions when nullable. Bumps `@automatons/parser` to `^1.1.0` and `@automatons/tools` to `^2.1.0`.