### PR TITLE
feat: render OpenAPI 3.2 query/additionalOperations and querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@automatons/parser": "^1.1.0",
-    "@automatons/tools": "^2.1.0",
+    "@automatons/parser": "^1.2.0",
+    "@automatons/tools": "^2.2.0",
     "prettier": "^3.8.3",
     "ts-morph": "^28.0.0"
   },

--- a/src/__tests__/generates/methods.spec.ts
+++ b/src/__tests__/generates/methods.spec.ts
@@ -1,0 +1,54 @@
+import {Openapi} from '@automatons/tools';
+import {rm} from "node:fs/promises";
+import {join} from 'path';
+import {generate} from "../../generator";
+import paths from "../../paths";
+import {expectFormat} from "../expects/expectFormat";
+
+const outDir = join(paths.tmp, 'methods');
+
+it('should generate the 3.2 query method and additionalOperations', async () => {
+  await generate(openapi, {path: '', openapiPath: '', outDir});
+
+  await expectFormat();
+});
+
+beforeEach(async () => {
+  await rm(outDir, {recursive: true, force: true});
+});
+
+const openapi: Openapi = {
+  openapi: '3.2.0',
+  info: {
+    title: 'example',
+    version: '0.0.0'
+  },
+  servers: [
+    {url: 'test'}
+  ],
+  paths: {
+    'items/': {
+      // 3.2 fixed query method (idempotent read with a request body)
+      query: {
+        operationId: 'queryItems',
+        requestBody: {
+          content: {
+            'application/json': {schema: {type: 'object', properties: {filter: {type: 'string'}}}}
+          }
+        },
+        responses: {
+          'application/json': {description: 'description', content: {'200': {schema: {type: 'object'}}}}
+        }
+      },
+      // 3.2 additionalOperations: arbitrary HTTP method
+      additionalOperations: {
+        PURGE: {
+          operationId: 'purgeItems',
+          responses: {
+            'application/json': {description: 'description', content: {'200': {schema: {type: 'object'}}}}
+          }
+        }
+      }
+    }
+  }
+};

--- a/src/__tests__/generates/querystring.spec.ts
+++ b/src/__tests__/generates/querystring.spec.ts
@@ -1,0 +1,49 @@
+import {Openapi} from '@automatons/tools';
+import {rm} from "node:fs/promises";
+import {join} from 'path';
+import {generate} from "../../generator";
+import paths from "../../paths";
+import {expectFormat} from "../expects/expectFormat";
+
+const outDir = join(paths.tmp, 'querystring');
+
+it('should generate a 3.2 querystring parameter', async () => {
+  await generate(openapi, {path: '', openapiPath: '', outDir});
+
+  await expectFormat();
+});
+
+beforeEach(async () => {
+  await rm(outDir, {recursive: true, force: true});
+});
+
+const openapi: Openapi = {
+  openapi: '3.2.0',
+  info: {
+    title: 'example',
+    version: '0.0.0'
+  },
+  servers: [
+    {url: 'test'}
+  ],
+  paths: {
+    'search/': {
+      get: {
+        operationId: 'search',
+        // 3.2 querystring: the whole query string described by one content schema
+        parameters: [{
+          in: 'querystring',
+          name: '',
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {type: 'object', properties: {q: {type: 'string'}, page: {type: 'integer'}}}
+            }
+          }
+        }],
+        responses: {
+          'application/json': {description: 'description', content: {'200': {schema: {type: 'object'}}}}
+        }
+      }
+    }
+  }
+};

--- a/src/extractors/api.ts
+++ b/src/extractors/api.ts
@@ -1,6 +1,6 @@
 import {AffectPath, Api, Path} from "@automatons/parser";
 
-const isAffectPath = (path: Path): path is AffectPath => ['post', 'patch', 'put'].includes(path.method);
+const isAffectPath = (path: Path): path is AffectPath => 'forms' in path;
 
 export const extractApiMeta = (api: Api) => {
   const hasTemplate = api.servers.some(server => server.values?.length)

--- a/src/generator/api.ts
+++ b/src/generator/api.ts
@@ -5,7 +5,7 @@ import {schemaToType} from "./schema";
 import {docs} from "./comment";
 import {extractApiMeta} from "../extractors/api";
 
-const isAffect = (path: Path): path is AffectPath => ["post", "put", "patch"].includes(path.method);
+const isAffect = (path: Path): path is AffectPath => "forms" in path;
 const formsOf = (path: Path): NonNullable<AffectPath["forms"]> => (isAffect(path) && path.forms ? path.forms : []);
 
 type Entry = {name: string; required?: boolean; schema: Schema};
@@ -38,6 +38,10 @@ const queriesParam = (path: Path): OptionalKind<ParameterDeclarationStructure> |
   path.queries?.length
     ? {name: "queries", type: objectType(path.queries), ...withInit(allOptional(path.queries) ? "{}" : undefined)}
     : undefined;
+const queryStringParam = (path: Path): OptionalKind<ParameterDeclarationStructure> | undefined =>
+  path.querystring
+    ? {name: "querystring", type: schemaToType(path.querystring), hasQuestionToken: true}
+    : undefined;
 const cookiesParam = (path: Path): OptionalKind<ParameterDeclarationStructure> | undefined =>
   path.cookies?.length
     ? {name: "cookies", type: objectType(path.cookies), ...withInit(allOptional(path.cookies) ? "{}" : undefined)}
@@ -64,6 +68,7 @@ const requestParams = (path: Path): OptionalKind<ParameterDeclarationStructure>[
     ...(path.parameters ?? []).map((p) => ({name: p.name, type: schemaToType(p.schema)})),
     forms.length ? {name: "form", type: forms.map((form) => schemaToType(form.schema)).join(" | ")} : undefined,
     queriesParam(path),
+    queryStringParam(path),
     cookiesParam(path),
     headersParam(path),
     serverParam(path),
@@ -71,16 +76,19 @@ const requestParams = (path: Path): OptionalKind<ParameterDeclarationStructure>[
   ]);
 };
 const configParams = (path: Path): OptionalKind<ParameterDeclarationStructure>[] =>
-  compact([queriesParam(path), cookiesParam(path), headersParam(path), serverParam(path), configParam()]);
+  compact([queriesParam(path), queryStringParam(path), cookiesParam(path), headersParam(path), serverParam(path), configParam()]);
 
 const requestVariables = (path: Path): string =>
   compact([
     path.queries?.length ? "queries" : undefined,
+    path.querystring ? "querystring" : undefined,
     path.cookies?.length ? "cookies" : undefined,
     "headers",
     path.servers?.length ? "server" : undefined,
     "config",
   ]).join(", ");
+
+const AXIOS_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"];
 
 const requestBody = (api: Api, path: Path): string[] => {
   const forms = formsOf(path);
@@ -88,11 +96,14 @@ const requestBody = (api: Api, path: Path): string[] => {
     .map((p) => `.replace("{${p.name}}", template('${p.name}', ${p.name}, '${p.style ?? "simple"}', ${p.explode ?? false}))`)
     .join("");
   void api;
+  const call = AXIOS_METHODS.includes(path.method)
+    ? `return this.axios.${path.method}(path, ${forms.length ? "_form, " : ""}requestConfig);`
+    : `return this.axios.request({ ...requestConfig, method: "${path.method.toUpperCase()}", url: path${forms.length ? ", data: _form" : ""} });`;
   return compact([
     `const path = "${path.path}"${replaces};`,
     `const requestConfig = await this.#config.${path.name}(${requestVariables(path)});`,
     forms.length ? "const _form = formData(headers['Content-Type'], form);" : undefined,
-    `return this.axios.${path.method}(path, ${forms.length ? "_form, " : ""}requestConfig);`,
+    call,
   ]);
 };
 
@@ -101,6 +112,7 @@ const configBody = (api: Api, path: Path): string[] => {
   const params = compact([
     "...config?.params,",
     ...(path.queries ?? []).map((q) => `...query("${q.name}", queries.${q.name}, '${q.style ?? "form"}', ${q.explode ?? false}),`),
+    path.querystring ? "...querystring," : undefined,
     ...securities.map((s) => (s.type === "apiKey" && s.in === "query" ? `${s.key}: await this.security("${s.name}"),` : undefined)),
   ]);
   const cookieStatements = compact<string>([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     testTimeout: 60000,
+    // generates specs share the tmp/ dir and each lints the whole tree, so run files
+    // sequentially to avoid a rm-during-lint race (ENOENT) as more specs are added.
+    fileParallelism: false,
     include: ['src/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,20 +43,20 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@automatons/parser@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@automatons/parser/-/parser-1.1.0.tgz#ab7c1dd3014f9d3477ceffe99d2af55104331f00"
-  integrity sha512-8gnA79Ch/TGDaXBO/3ueP+SB42gwlU9kJn34ilR99CubR106j+ZENL7NqTqgMHknH00tBXyK7z+CqJe5WZxXlg==
+"@automatons/parser@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@automatons/parser/-/parser-1.2.0.tgz#463bce0b32306dd65d685dcd2fb68878e33e2e34"
+  integrity sha512-svuvgKNyuLhA4QklwRO5944aLJo43gfiECnzg1gRiOt8kSASMrZlsUgry+MvQ/NChI1Y0YRMZiMSbgk5xIiUMA==
   dependencies:
-    "@automatons/tools" "^2.1.0"
+    "@automatons/tools" "^2.2.0"
     change-case "^5.4.4"
 
-"@automatons/tools@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.1.0.tgz#b8bb2f4495b011d1aacd4cd094df506cebde6dc1"
-  integrity sha512-l7Vu9qFqz8qG7lyBw8BweEIJtZAnKGHir/Og+2IVKmBoXtu0y36V3UxLGUsBf0pgiin4ymMeoPNksO38cXBVOw==
+"@automatons/tools@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.2.0.tgz#8aa60b9ca53040e0f1c02659d5c23e75603f6be0"
+  integrity sha512-JeehWbzyK1Efrz3YlJCXlKxOQQzjFriVN1WSuO3D6mM71coWESoJ4EJWyP8BA01mdJpvQ/YoZe/Os7A4K2Gejg==
   dependencies:
-    js-yaml "^4.1.0"
+    js-yaml "^4.2.0"
 
 "@babel/code-frame@^7.0.0":
   version "7.16.7"
@@ -3794,6 +3794,13 @@ js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Emits client methods for the 3.2 `query` method and `additionalOperations` (`axios.request` for non-standard verbs), and a `querystring` parameter spread into the query params. Body detection now keys off the request body, not the method name. Bumps `@automatons/parser` to `^1.2.0` and `@automatons/tools` to `^2.2.0`.